### PR TITLE
Add license to sardana-training

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,38 @@
+Sardana-Training documentation is Free Software Documentation by
+ALBA Synchrotron (Carrer de la Llum, 2-26, 08290 Cerdanyola del Vallès,
+Barcelona)
+
+SECTION 1: GENERAL LICENSE FOR SARDANA-TRAINING DOCUMENTATION
+=============================================================
+
+The Sardana-Training files, except for the cases described in SECTION 2,
+are distributed under a Creative Commons Attribution 4.0 (CC-BY)
+International License:
+See <https://creativecommons.org/licenses/by/4.0/legalcode>
+See <http://creativecommons.org/licenses/by/4.0/>
+
+
+SECTION 2: EXCEPTIONS
+=====================
+
+Some files (e.g., those authored by 3rd parties or the documentation
+sources) are distributed under Free Software / documentation licenses
+that may differ from the the general one defined in SECTION 1.
+
+The following is a list of these exceptions:
+
+2.1: Python Code files (.py):
+-----------------------------
+
+The .py scripts are distributed under the GNU Lesser General Public License
+as published by the Free Software Foundation, either version 3 of the License,
+or (at your option) any later version:
+See <http://www.gnu.org/licenses/>
+
+2.2: Explicit copyright info in header/metadata:
+------------------------------------------------
+
+If a file contains an explicit license or other copyright information in
+its header or metadata which differs from the one defined in SECTION 1,
+such license/copyright info mentioned in the header/metadata prevails.
+

--- a/contributors.ipynb
+++ b/contributors.ipynb
@@ -5,6 +5,23 @@
    "metadata": {
     "collapsed": true,
     "slideshow": {
+     "slide_type": "notes"
+    }
+   },
+   "source": [
+    "> License notice:\n",
+    "\n",
+    "> This file is part of Sardana-Training Documentation    \n",
+    "> 2017 ALBA Synchrotron (Carrer de la Llum, 2-26, 08290 Cerdanyola, Barcelona)  \n",
+    "> This file is distributed under a Creative Commons Attribution 4.0 (CC-BY) International License:  \n",
+    "> See <https://creativecommons.org/licenses/by/4.0/legalcode>  \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "slideshow": {
      "slide_type": "slide"
     }
    },


### PR DESCRIPTION
Add license to sardana-training.

Licensing jupyter-notebook documentation files under CC-BY 4.0.
Licensing python script files (.py) under LGPL v3.0.